### PR TITLE
Feature/generify when methods

### DIFF
--- a/androidsample/src/androidTest/java/io/appflate/restmock/androidsample/tests/MainActivityTest.java
+++ b/androidsample/src/androidTest/java/io/appflate/restmock/androidsample/tests/MainActivityTest.java
@@ -47,7 +47,7 @@ public class MainActivityTest {
     public void setUp() throws Exception {
         pageObject = new MainActivityPageObject();
         //be sure to reset it before each test!
-        RESTMockServer.removeAllMatchableCalls();
+        RESTMockServer.reset();
     }
 
     @Test

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,4 +41,12 @@ artifacts {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    compile 'org.hamcrest:hamcrest-core:1.3'
+
+    testCompile 'junit:junit:4.11'
+    testCompile 'org.mockito:mockito-all:1.9.5'
+    testCompile 'com.squareup.okhttp3:okhttp:3.2.0'
 }
+
+jar.dependsOn test
+install.dependsOn test

--- a/core/src/main/java/io/appflate/restmock/MatchableCall.java
+++ b/core/src/main/java/io/appflate/restmock/MatchableCall.java
@@ -45,9 +45,11 @@ public class MatchableCall {
      * Same as {@link MatchableCall#thenReturnString(int, String)}, but with the default {@code responseCode} of 200
      *
      * <p>This {@code MatchableCall} will be automatically scheduled within the {@link RESTMockServer} if you want to prevent that, see {@link MatchableCall#dontSet()}</p>
+     * @param string body contents to be returned with the response
+     * @return this {@code MatchableCall}
      */
-    public MatchableCall thenReturnString(String json) {
-        return thenReturnString(200, json);
+    public MatchableCall thenReturnString(String string) {
+        return thenReturnString(200, string);
     }
 
     /**
@@ -57,7 +59,7 @@ public class MatchableCall {
      *
      * @param responseCode a http response code to use for the response.
      * @param responseString         responseString string to return for this matchableCall's request.
-     * @return his {@code MatchableCall}
+     * @return this {@code MatchableCall}
      */
     public MatchableCall thenReturnString(int responseCode,
                                           String responseString) {

--- a/core/src/main/java/io/appflate/restmock/MatchableCallsRequestDispatcher.java
+++ b/core/src/main/java/io/appflate/restmock/MatchableCallsRequestDispatcher.java
@@ -45,9 +45,9 @@ class MatchableCallsRequestDispatcher extends Dispatcher {
             return createErrorResponse(
                     new IllegalStateException(message));
         } else {
-            RESTMockServer.logger.error("<- Response ERROR:\t NOT MOCKED: " + recordedRequest);
+            RESTMockServer.logger.error("<- Response ERROR:\t" + RESTMockServer.RESPONSE_NOT_MOCKED + ": " + recordedRequest);
             MockResponse mockResponse =
-                    new MockResponse().setResponseCode(500).setBody("NOT_MOCKED");
+                    new MockResponse().setResponseCode(500).setBody(RESTMockServer.RESPONSE_NOT_MOCKED);
             return mockResponse;
         }
     }
@@ -55,7 +55,7 @@ class MatchableCallsRequestDispatcher extends Dispatcher {
     private String prepareTooManyMatchesMessage(RecordedRequest recordedRequest,
                                                 final List<MatchableCall> matchedRequests) {
         StringBuilder sb =
-                new StringBuilder("there are more than one response matching this request:" + recordedRequest + ": ");
+                new StringBuilder(RESTMockServer.MORE_THAN_ONE_RESPONSE_ERROR + recordedRequest + ": ");
         for (MatchableCall match : matchedRequests) {
             sb.append(match.requestMatcher.toString()).append("\n");
         }
@@ -79,7 +79,6 @@ class MatchableCallsRequestDispatcher extends Dispatcher {
         e.printStackTrace(pw);
         response.setBody(sw.toString());
         response.setResponseCode(500);
-        response.addHeader("Exception", e.getLocalizedMessage());
         return response;
     }
 

--- a/core/src/main/java/io/appflate/restmock/RESTMockServer.java
+++ b/core/src/main/java/io/appflate/restmock/RESTMockServer.java
@@ -37,8 +37,10 @@ import static org.hamcrest.core.AllOf.allOf;
 
 public class RESTMockServer {
 
-    private static MockWebServer mockWebServer;
-    private static MatchableCallsRequestDispatcher dispatcher;
+    public static final String RESPONSE_NOT_MOCKED = "NOT MOCKED";
+    public static final String MORE_THAN_ONE_RESPONSE_ERROR = "There are more than one response matching this request: ";
+    static MockWebServer mockWebServer;
+    static MatchableCallsRequestDispatcher dispatcher;
     private static String serverBaseUrl;
     private static RESTMockFileParser RESTMockFileParser;
     static RESTMockLogger logger;
@@ -81,9 +83,16 @@ public class RESTMockServer {
     }
 
     /**
-     * removes all matchable calls stored in this {@code RESTMockServer}
+     * Use {@link #reset() instead}
      */
+    @Deprecated
     public static void removeAllMatchableCalls() {
+        reset();
+    }
+    /**
+     * removes all mocks stored in this {@code RESTMockServer}
+     */
+    public static void reset() {
         dispatcher.removeAllMatchableCalls();
     }
 
@@ -186,5 +195,13 @@ public class RESTMockServer {
      */
     public static MatchableCall whenRequested(Matcher<RecordedRequest> requestMatcher) {
         return new MatchableCall(RESTMockServer.RESTMockFileParser, requestMatcher, dispatcher);
+    }
+
+    /**
+     * Shuts down the instance of RESTMockServer
+     * @throws IOException if something goes wrong while stopping
+     */
+    public static void shutdown() throws IOException {
+        mockWebServer.shutdown();
     }
 }

--- a/core/src/main/java/io/appflate/restmock/RESTMockServer.java
+++ b/core/src/main/java/io/appflate/restmock/RESTMockServer.java
@@ -132,7 +132,7 @@ public class RESTMockServer {
      * @param requestMatcher matcher to match a GET request
      * @return {@code MatchableCall} that will match GET requests along with {@code requestMatcher}
      */
-    public static MatchableCall whenGET(RequestMatcher requestMatcher) {
+    public static MatchableCall whenGET(Matcher<RecordedRequest> requestMatcher) {
         return RESTMockServer.whenRequested(allOf(isGET(), requestMatcher));
     }
 
@@ -142,7 +142,7 @@ public class RESTMockServer {
      * @param requestMatcher matcher to match a POST request
      * @return {@code MatchableCall} that will match POST requests along with {@code requestMatcher}
      */
-    public static MatchableCall whenPOST(RequestMatcher requestMatcher) {
+    public static MatchableCall whenPOST(Matcher<RecordedRequest>  requestMatcher) {
         return RESTMockServer.whenRequested(allOf(isPOST(), requestMatcher));
     }
 
@@ -152,7 +152,7 @@ public class RESTMockServer {
      * @param requestMatcher matcher to match a PUT request
      * @return {@code MatchableCall} that will match PUT requests along with {@code requestMatcher}
      */
-    public static MatchableCall whenPUT(RequestMatcher requestMatcher) {
+    public static MatchableCall whenPUT(Matcher<RecordedRequest>  requestMatcher) {
         return RESTMockServer.whenRequested(allOf(isPUT(), requestMatcher));
     }
 
@@ -162,7 +162,7 @@ public class RESTMockServer {
      * @param requestMatcher matcher to match a PATCH request
      * @return {@code MatchableCall} that will match PATCH requests along with {@code requestMatcher}
      */
-    public static MatchableCall whenPATCH(RequestMatcher requestMatcher) {
+    public static MatchableCall whenPATCH(Matcher<RecordedRequest>  requestMatcher) {
         return RESTMockServer.whenRequested(allOf(isPATCH(), requestMatcher));
     }
 
@@ -172,7 +172,7 @@ public class RESTMockServer {
      * @param requestMatcher matcher to match a DELETE request
      * @return {@code MatchableCall} that will match DELETE requests along with {@code requestMatcher}
      */
-    public static MatchableCall whenDELETE(RequestMatcher requestMatcher) {
+    public static MatchableCall whenDELETE(Matcher<RecordedRequest>  requestMatcher) {
         return RESTMockServer.whenRequested(allOf(isDELETE(), requestMatcher));
     }
 

--- a/core/src/main/java/io/appflate/restmock/utils/RequestMatcher.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RequestMatcher.java
@@ -25,7 +25,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * <p>A RequestMatcher is an extension of {@link org.hamcrest.TypeSafeMatcher} making it easier to specify
  * the matcher without the need of implementing {@link #describeTo(Description)} method.</p>
- * <p>
  * <p>See {@link org.hamcrest.Matcher} for more info about hamcrest's matchers</p>
  */
 public abstract class RequestMatcher extends TypeSafeMatcher<RecordedRequest> {

--- a/core/src/test/java/io/appflate/restmock/RESTMockServerTest.java
+++ b/core/src/test/java/io/appflate/restmock/RESTMockServerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016 Appflate.io
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appflate.restmock;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import io.appflate.restmock.utils.TestUtils;
+import okhttp3.OkHttpClient;
+
+import static io.appflate.restmock.utils.RequestMatchers.pathEndsWith;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Created by andrzejchm on 25/04/16.
+ */
+public class RESTMockServerTest {
+    static RESTMockFileParser fileParser;
+
+    @BeforeClass
+    public static void setupClass() {
+        fileParser = mock(RESTMockFileParser.class);
+        RESTMockServerStarter.startSync(fileParser);
+        RESTMockServer.dispatcher = spy(RESTMockServer.dispatcher);
+    }
+
+    @Before
+    public void setup() {
+        RESTMockServer.reset();
+    }
+
+    @Test
+    public void testWhenGET() throws Exception {
+        String path = "/sample";
+        String worksBody = "works";
+        MatchableCall matchableCall = RESTMockServer.whenGET(pathEndsWith(path));
+        assertNotNull(matchableCall);
+        assertNull(matchableCall.response);
+        verify(RESTMockServer.dispatcher, never()).addMatchableCall(matchableCall);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        matchableCall.thenReturnString(worksBody);
+        TestUtils.assertResponseWithBodyContains(TestUtils.get(path), 200, "works");
+        TestUtils.assertNotMocked(TestUtils.post(path));
+        TestUtils.assertNotMocked(TestUtils.delete(path));
+        TestUtils.assertNotMocked(TestUtils.put(path));
+    }
+
+    @Test
+    public void testWhenPOST() throws Exception {
+        String path = "/sample";
+        String worksBody = "works";
+        MatchableCall matchableCall = RESTMockServer.whenPOST(pathEndsWith(path));
+        assertNotNull(matchableCall);
+        assertNull(matchableCall.response);
+        verify(RESTMockServer.dispatcher, never()).addMatchableCall(matchableCall);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        matchableCall.thenReturnString(worksBody);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        TestUtils.assertResponseWithBodyContains(TestUtils.post(path), 200, "works");
+        TestUtils.assertNotMocked(TestUtils.delete(path));
+        TestUtils.assertNotMocked(TestUtils.put(path));
+    }
+
+    @Test
+    public void testWhenPUT() throws Exception {
+        String path = "/sample";
+        String worksBody = "works";
+        MatchableCall matchableCall = RESTMockServer.whenPUT(pathEndsWith(path));
+        assertNotNull(matchableCall);
+        assertNull(matchableCall.response);
+        verify(RESTMockServer.dispatcher, never()).addMatchableCall(matchableCall);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        matchableCall.thenReturnString(worksBody);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        TestUtils.assertNotMocked(TestUtils.post(path));
+        TestUtils.assertNotMocked(TestUtils.delete(path));
+        TestUtils.assertResponseWithBodyContains(TestUtils.put(path), 200, "works");
+    }
+
+    @Test
+    public void testWhenDELETE() throws Exception {
+        String path = "/sample";
+        String worksBody = "works";
+        MatchableCall matchableCall = RESTMockServer.whenDELETE(pathEndsWith(path));
+        assertNotNull(matchableCall);
+        assertNull(matchableCall.response);
+        verify(RESTMockServer.dispatcher, never()).addMatchableCall(matchableCall);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        matchableCall.thenReturnString(worksBody);
+        TestUtils.assertNotMocked(TestUtils.get(path));
+        TestUtils.assertNotMocked(TestUtils.post(path));
+        TestUtils.assertResponseWithBodyContains(TestUtils.delete(path), 200, worksBody);
+        TestUtils.assertNotMocked(TestUtils.put(path));
+    }
+
+    @Test
+    public void testMultipleMatches() throws Exception {
+        String path = "sample";
+        RESTMockServer.whenRequested(pathEndsWith(path)).thenReturnString("multiple calls");
+        RESTMockServer.whenRequested(pathEndsWith(path)).thenReturnString("multiple calls another");
+        TestUtils.assertMultipleMatches(TestUtils.get(path));
+        TestUtils.assertMultipleMatches(TestUtils.post(path));
+        TestUtils.assertMultipleMatches(TestUtils.delete(path));
+        TestUtils.assertMultipleMatches(TestUtils.put(path));
+    }
+
+    @AfterClass
+    public static void teardownClass() throws IOException {
+        RESTMockServer.shutdown();
+    }
+}

--- a/core/src/test/java/io/appflate/restmock/utils/TestUtils.java
+++ b/core/src/test/java/io/appflate/restmock/utils/TestUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Appflate.io
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.appflate.restmock.utils;
+
+import java.io.IOException;
+
+import io.appflate.restmock.RESTMockServer;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by andrzejchm on 25/04/16.
+ */
+public class TestUtils {
+    private static final RequestBody EMPTY_JSON_BODY = RequestBody.create(MediaType.parse(
+            "application/json; charset=utf-8"), "");
+    private static OkHttpClient okHttpClient = new OkHttpClient();
+
+    public static Response get(String path) throws IOException {
+        path = normalizePath(path);
+        return executeSync(new Request.Builder().url(RESTMockServer.getUrl() + path).build());
+    }
+
+    public static Response post(String path) throws IOException {
+        path = normalizePath(path);
+        return executeSync(new Request.Builder().url(RESTMockServer.getUrl() + path).method("POST",
+                EMPTY_JSON_BODY).build());
+    }
+
+    public static Response put(String path) throws IOException {
+        path = normalizePath(path);
+        return executeSync(new Request.Builder().url(RESTMockServer.getUrl() + path).method("PUT",
+                EMPTY_JSON_BODY).build());
+    }
+
+    public static Response delete(String path) throws IOException {
+        path = normalizePath(path);
+        return executeSync(new Request.Builder().url(RESTMockServer.getUrl() + path).method("DELETE",
+                null).build());
+    }
+
+    private static Response executeSync(Request request) throws IOException {
+        return okHttpClient.newCall(request).execute();
+    }
+
+    public static void assertNotMocked(Response response) throws IOException {
+        assertResponseWithBodyContains(response, 500, RESTMockServer.RESPONSE_NOT_MOCKED);
+    }
+
+    public static void assertMultipleMatches(Response response) throws IOException {
+        assertResponseWithBodyContains(response, 500, RESTMockServer.MORE_THAN_ONE_RESPONSE_ERROR);
+
+    }
+
+    public static void assertResponseWithBodyContains(Response response,
+                                                      int code,
+                                                      String body) throws IOException {
+        assertEquals(code, response.code());
+        assertTrue(response.body().string().contains(body));
+    }
+
+    private static String normalizePath(String path) {
+        if (path.startsWith("/")) {
+            path = "/" + path;
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
* added unit tests for `RESTMockServer`
* generified `when*` methods in `RESTMockServer` to make it possible to use meta-matchers like `allOf` and `anyOf`
* renamed method `removeAllMatchableCalls()` to `reset()`
* added hamcrest as a dependency since not all are using Espresso