### PR TITLE
remove application tag in AndroidManifest.xml;

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ Add the dependency
 ```groovy  
 dependencies {
 	androidTestCompile 'com.github.andrzejchm.RESTMock:android:0.0.4'
-	androidTestCompile('com.github.andrzejchm.RESTMock:core:0.0.4') {
-        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
-    }
 }
 ```
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,8 +14,4 @@
   ~ limitations under the License.
   -->
 
-<manifest package="io.appflate.restmock.android">
-
-    <application/>
-
-</manifest>
+<manifest package="io.appflate.restmock.android"/>

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
1. remove application tag in AndroidManifest.xml;
2. update gradle android plugin to 2.1.0;
3. cleanup readme;

I have a problem with using RESTMock 0.0.4 and espresso 2.2.2, with the error below:

```bash
:app:processDevDebugAndroidTestManifest
/Users/piasy/src/AndroidTDDBootStrap/app/build/intermediates/manifest/tmp/manifestMerger5470924077765874458.xml:28:9-41 Error:
    Attribute application@label value=(@string/app_name) from [com.github.andrzejchm.RESTMock:android:0.0.4] AndroidManifest.xml:28:9-41
    is also present at [com.android.support.test.espresso:espresso-intents:2.2.2] AndroidManifest.xml:24:18-41 value=(Intents).
    Suggestion: add 'tools:replace="android:label"' to <application> element at manifestMerger5470924077765874458.xml:7:5-9:19 to override.
See http://g.co/androidstudio/manifest-merger for more information about the manifest merger.
:app:processDevDebugAndroidTestManifest FAILED
Error:Execution failed for task ':app:processDevDebugAndroidTestManifest'.
> java.lang.RuntimeException: Manifest merger failed : Attribute application@label value=(@string/app_name) from [com.github.andrzejchm.RESTMock:android:0.0.4] AndroidManifest.xml:28:9-41
      is also present at [com.android.support.test.espresso:espresso-intents:2.2.2] AndroidManifest.xml:24:18-41 value=(Intents).
      Suggestion: add 'tools:replace="android:label"' to <application> element at manifestMerger5470924077765874458.xml:7:5-9:19 to override.
Information:BUILD FAILED
```

I've test on my local machine that remove the `application` tag in AndroidManifest.xml will fix this problem, besides, there is no need to add `application` tag in AndroidManifest.xml.

Reproduce project is there: https://github.com/Piasy/AndroidTDDBootStrap/tree/02a65a708a66b9e98be07a00a8e3146b652c8398/, update [this line](https://github.com/Piasy/AndroidTDDBootStrap/blob/02a65a708a66b9e98be07a00a8e3146b652c8398/buildsystem/dependencies.gradle#L32) into `2.2.2` will reproduce this problem.