### PR TITLE
Feature/query parameters

### DIFF
--- a/core/src/main/java/io/appflate/restmock/RESTMockServer.java
+++ b/core/src/main/java/io/appflate/restmock/RESTMockServer.java
@@ -16,22 +16,21 @@
 
 package io.appflate.restmock;
 
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-
 import org.hamcrest.Matcher;
 
 import java.io.IOException;
 
 import io.appflate.restmock.logging.NOOpLogger;
 import io.appflate.restmock.logging.RESTMockLogger;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import static io.appflate.restmock.utils.RequestMatchers.isDELETE;
 import static io.appflate.restmock.utils.RequestMatchers.isGET;
+import static io.appflate.restmock.utils.RequestMatchers.isHEAD;
 import static io.appflate.restmock.utils.RequestMatchers.isPATCH;
 import static io.appflate.restmock.utils.RequestMatchers.isPOST;
 import static io.appflate.restmock.utils.RequestMatchers.isPUT;
-import static io.appflate.restmock.utils.RequestMatchers.isHEAD;
 import static org.hamcrest.core.AllOf.allOf;
 
 
@@ -43,7 +42,7 @@ public class RESTMockServer {
     static MatchableCallsRequestDispatcher dispatcher;
     private static String serverBaseUrl;
     private static RESTMockFileParser RESTMockFileParser;
-    static RESTMockLogger logger;
+    public static RESTMockLogger logger = new NOOpLogger();
 
     public synchronized static void init(RESTMockFileParser RESTMockFileParser,
                             RESTMockLogger logger) throws IOException {
@@ -51,11 +50,10 @@ public class RESTMockServer {
             RESTMockServer.shutdown();
         }
         RESTMockServer.mockWebServer = new MockWebServer();
-        if (logger == null) {
-            RESTMockServer.logger = new NOOpLogger();
-        } else {
+        if (logger != null) {
             RESTMockServer.logger = logger;
         }
+
         RESTMockServer.logger.log("## Starting RESTMock server...");
         RESTMockServer.dispatcher = new MatchableCallsRequestDispatcher();
         RESTMockServer.mockWebServer.setDispatcher(dispatcher);

--- a/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
+++ b/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
@@ -1,0 +1,22 @@
+package io.appflate.restmock.utils;
+
+/**
+ * A key/value set representing query parameters in an HTTP request.
+ */
+public class QueryParam {
+  private String key;
+  private String value;
+
+  public QueryParam (String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public String getKey() {
+    return this.key;
+  }
+
+  public String getValue() {
+    return this.value;
+  }
+}

--- a/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
+++ b/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
@@ -1,22 +1,72 @@
 package io.appflate.restmock.utils;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  * A key/value set representing query parameters in an HTTP request.
  */
 public class QueryParam {
   private String key;
-  private String value;
+  private List<String> values;
 
-  public QueryParam (String key, String value) {
+  public QueryParam(String key, List<String> values) {
     this.key = key;
-    this.value = value;
+    this.values = values;
+  }
+
+  public QueryParam(String key, String... values) {
+    this.key = key;
+    this.values = new LinkedList<>();
+
+    for (String val : values) {
+      this.values.add(val);
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof QueryParam)) {
+      return false;
+    }
+
+    QueryParam otherQueryParam = (QueryParam) other;
+
+    if (this == other) {
+      return true;
+    }
+
+    if (!this.key.equals(otherQueryParam.key)) {
+      return false;
+    }
+
+    if (this.values.size() != otherQueryParam.values.size()) {
+      return false;
+    }
+
+    for (String nextVal : this.values) {
+      if (!otherQueryParam.values.contains(nextVal)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 37 * result + (key == null ? 0 : key.hashCode());
+    result = 37 * result + (values == null ? 0 : values.hashCode());
+
+    return result;
   }
 
   public String getKey() {
     return this.key;
   }
 
-  public String getValue() {
-    return this.value;
+  public List<String> getValues() {
+    return this.values;
   }
 }

--- a/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
+++ b/core/src/main/java/io/appflate/restmock/utils/QueryParam.java
@@ -7,8 +7,8 @@ import java.util.List;
  * A key/value set representing query parameters in an HTTP request.
  */
 public class QueryParam {
-  private String key;
-  private List<String> values;
+  private final String key;
+  private final List<String> values;
 
   public QueryParam(String key, List<String> values) {
     this.key = key;

--- a/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
@@ -21,7 +21,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import okhttp3.mockwebserver.RecordedRequest;
 
@@ -84,7 +83,7 @@ public class RequestMatchers {
         protected boolean matchesSafely(RecordedRequest item) {
           try {
             URL mockUrl = new URL("http", "localhost", item.getPath());
-            Map<String, List<String>> queryParams = RestMockUtils.splitQuery(mockUrl);
+            List<QueryParam> queryParams = RestMockUtils.splitQuery(mockUrl);
             return queryParams.size() > 0;
           } catch (MalformedURLException e) {
             return false;
@@ -114,18 +113,13 @@ public class RequestMatchers {
         protected boolean matchesSafely(RecordedRequest item) {
           try {
             URL mockUrl = new URL("http", "localhost", item.getPath());
-            Map<String, List<String>> queryParams = RestMockUtils.splitQuery(mockUrl);
-            if (queryParams.size() == 0 || queryParams.size() != expectedParams.length) {
+            List<QueryParam> actualParams = RestMockUtils.splitQuery(mockUrl);
+            if (actualParams.size() == 0 || actualParams.size() != expectedParams.length) {
               return false;
             }
 
             for (QueryParam param : expectedParams) {
-              if (!queryParams.containsKey(param.getKey())) {
-                return false;
-              }
-
-              List<String> paramValues = queryParams.get(param.getKey());
-              if (!paramValues.contains(param.getValue())) {
+              if (!actualParams.contains(param)) {
                 return false;
               }
             }

--- a/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
@@ -22,6 +22,8 @@ import java.net.URL;
 import java.util.List;
 import java.util.Locale;
 
+import io.appflate.restmock.RESTMockServer;
+import io.appflate.restmock.logging.RESTMockLogger;
 import okhttp3.mockwebserver.RecordedRequest;
 
 public class RequestMatchers {
@@ -126,6 +128,7 @@ public class RequestMatchers {
 
             return true;
           } catch (MalformedURLException e) {
+            RESTMockServer.logger.error("URL appears to be malformed with path: " + item.getPath());
             return false;
           } catch (UnsupportedEncodingException e) {
             return false;

--- a/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
@@ -46,32 +46,39 @@ public final class RestMockUtils {
     /**
      * Extract query parameters from a {@link URL}.
      *
-     * Note: Gratuitously stolen from http://stackoverflow.com/a/13592567/281460
-     *
      * @param url The {@link URL} to retrieve query parameters for.
      *
-     * @return A {@link Map} of {@link String} key / a {@link List} of {@link String} value pairs
-     *         appearing in the query parameters of the given URL. This will never be null.
+     * @return A {@link List} of {@link QueryParam} objects. Each parameter has one key, and zero or
+     *         more values.
      *
      * @throws UnsupportedEncodingException If unable to decode from UTF-8. This should never happen.
      */
-    public static Map<String, List<String>> splitQuery(URL url) throws UnsupportedEncodingException {
-      final Map<String, List<String>> queryPairs = new LinkedHashMap<String, List<String>>();
+    public static List<QueryParam> splitQuery(URL url) throws UnsupportedEncodingException {
+      final Map<String, List<String>> queryPairs = new LinkedHashMap<>();
       final String[] pairs = url.getQuery().split("&");
       for (String pair : pairs) {
         final int idx = pair.indexOf("=");
         final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
         List<String> valueList = new LinkedList<>();
+
         if (queryPairs.containsKey(key)) {
-          final String value =
-            idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8")
-                                               : null;
-          valueList.add(value);
+          valueList = queryPairs.get(key);
         }
+
+        final String value =
+          idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8")
+                                             : null;
+        valueList.add(value);
 
         queryPairs.put(key, valueList);
       }
 
-      return queryPairs;
+      List<QueryParam> finalParamList = new LinkedList<>();
+      for (String key : queryPairs.keySet()) {
+        QueryParam nextFinalParam = new QueryParam(key, queryPairs.get(key));
+        finalParamList.add(nextFinalParam);
+      }
+
+      return finalParamList;
     }
 }

--- a/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
@@ -17,9 +17,16 @@
 
 package io.appflate.restmock.utils;
 
-import okhttp3.mockwebserver.MockResponse;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import io.appflate.restmock.RESTMockFileParser;
+import okhttp3.mockwebserver.MockResponse;
 
 public final class RestMockUtils {
 
@@ -34,5 +41,32 @@ public final class RestMockUtils {
             throws Exception {
         String fileContents = RESTMockFileParser.readJsonFile(jsonFilePath);
         return new MockResponse().setResponseCode(responseCode).setBody(fileContents);
+    }
+
+    /**
+     * Extract query parameters from a {@link URL}.
+     *
+     * Note: Gratuitously stolen from http://stackoverflow.com/a/13592567/281460
+     *
+     * @param url The {@link URL} to retrieve query parameters for.
+     *
+     * @return A {@link Map} of {@link String} key / a {@link List} of {@link String} value pairs
+     *         appearing in the query parameters of the given URL. This will never be null.
+     *
+     * @throws UnsupportedEncodingException If unable to decode from UTF-8. This should never happen.
+     */
+    public static Map<String, List<String>> splitQuery(URL url) throws UnsupportedEncodingException {
+      final Map<String, List<String>> query_pairs = new LinkedHashMap<String, List<String>>();
+      final String[] pairs = url.getQuery().split("&");
+      for (String pair : pairs) {
+        final int idx = pair.indexOf("=");
+        final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
+        if (!query_pairs.containsKey(key)) {
+          query_pairs.put(key, new LinkedList<String>());
+        }
+        final String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8") : null;
+        query_pairs.get(key).add(value);
+      }
+      return query_pairs;
     }
 }

--- a/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
@@ -56,17 +56,22 @@ public final class RestMockUtils {
      * @throws UnsupportedEncodingException If unable to decode from UTF-8. This should never happen.
      */
     public static Map<String, List<String>> splitQuery(URL url) throws UnsupportedEncodingException {
-      final Map<String, List<String>> query_pairs = new LinkedHashMap<String, List<String>>();
+      final Map<String, List<String>> queryPairs = new LinkedHashMap<String, List<String>>();
       final String[] pairs = url.getQuery().split("&");
       for (String pair : pairs) {
         final int idx = pair.indexOf("=");
         final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
-        if (!query_pairs.containsKey(key)) {
-          query_pairs.put(key, new LinkedList<String>());
+        List<String> valueList = new LinkedList<>();
+        if (queryPairs.containsKey(key)) {
+          final String value =
+            idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8")
+                                               : null;
+          valueList.add(value);
         }
-        final String value = idx > 0 && pair.length() > idx + 1 ? URLDecoder.decode(pair.substring(idx + 1), "UTF-8") : null;
-        query_pairs.get(key).add(value);
+
+        queryPairs.put(key, valueList);
       }
-      return query_pairs;
+
+      return queryPairs;
     }
 }

--- a/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RestMockUtils.java
@@ -74,8 +74,8 @@ public final class RestMockUtils {
       }
 
       List<QueryParam> finalParamList = new LinkedList<>();
-      for (String key : queryPairs.keySet()) {
-        QueryParam nextFinalParam = new QueryParam(key, queryPairs.get(key));
+      for (Map.Entry<String, List<String>> entry: queryPairs.entrySet()) {
+        QueryParam nextFinalParam = new QueryParam(entry.getKey(), entry.getValue());
         finalParamList.add(nextFinalParam);
       }
 

--- a/core/src/test/java/io/appflate/restmock/QueryParamTest.java
+++ b/core/src/test/java/io/appflate/restmock/QueryParamTest.java
@@ -1,0 +1,40 @@
+package io.appflate.restmock;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.List;
+
+import io.appflate.restmock.utils.QueryParam;
+import io.appflate.restmock.utils.RestMockUtils;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class QueryParamTest {
+  @Test
+  public void testBasicQueryParamSplit() throws Exception {
+    URL url = new URL("https://www.jwir3.com/someRequest?flag=true&session_length=2");
+
+    List<QueryParam> params = RestMockUtils.splitQuery(url);
+
+    QueryParam expectedParam1 = new QueryParam("flag", "true");
+    QueryParam expectedParam2 = new QueryParam("session_length", "2");
+
+    assertEquals(2, params.size());
+    assertTrue(params.contains(expectedParam1));
+    assertTrue(params.contains(expectedParam2));
+  }
+
+  @Test
+  public void testMultipleValueQueryParamSplit() throws Exception {
+    URL url = new URL("https://www.jwir3.com/someRequest?user_id=1&user_id=2");
+
+    List<QueryParam> params = RestMockUtils.splitQuery(url);
+
+    QueryParam expectedParam1 = new QueryParam("user_id", "2", "1");
+
+    assertEquals(1, params.size());
+    assertTrue(params.contains(expectedParam1));
+  }
+}

--- a/core/src/test/java/io/appflate/restmock/RESTMockServerTest.java
+++ b/core/src/test/java/io/appflate/restmock/RESTMockServerTest.java
@@ -28,16 +28,11 @@ import io.appflate.restmock.utils.TestUtils;
 import static io.appflate.restmock.utils.RequestMatchers.pathEndsWith;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-/**
- * Created by andrzejchm on 25/04/16.
- */
 public class RESTMockServerTest {
     static RESTMockFileParser fileParser;
 


### PR DESCRIPTION
Adds two methods: `hasQueryParameters()` and `hasQueryParameters(AbstractMap.SimpleEntry<String, String> params...)`. The latter version checks whether the request has _exactly_ the query parameters specified, whereas the former checks whether there are _any_ parameters given at all.  