### PR TITLE
(#41): Update OkHttp to 3.4.1 to avoid security problems.

### DIFF
--- a/androidsample/build.gradle
+++ b/androidsample/build.gradle
@@ -59,7 +59,7 @@ configurations.all {
   resolutionStrategy {
     force "com.android.support:support-annotations:${supportLibraryVersion}"
     force 'com.squareup.okio:okio:1.8.0'
-    force 'com.squareup.okhttp3:okhttp:3.3.0'
+    force "com.squareup.okhttp3:okhttp:${okHttpVersion}"
   }
 }
 dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,12 +41,12 @@ artifacts {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:mockwebserver:3.4.0'
+    compile "com.squareup.okhttp3:mockwebserver:${okHttpVersion}"
     compile 'org.hamcrest:hamcrest-core:1.3'
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-all:1.9.5'
-    testCompile 'com.squareup.okhttp3:okhttp:3.4.0'
+    testCompile "com.squareup.okhttp3:okhttp:${okHttpVersion}"
 }
 
 jar.dependsOn test

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,3 +34,4 @@
 # org.gradle.parallel=true
 
 supportLibraryVersion=24.2.0
+okHttpVersion=3.4.1


### PR DESCRIPTION
Fixes #41.