### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RESTMockServer.whenGET(pathContains("users/defunkt"))
 **Article**
 - [ITDD - Instrumentation TDD for Android](https://medium.com/@andrzejchm/ittd-instrumentation-ttd-for-android-4894cbb82d37)
 
-##Table of Contents
+## Table of Contents
 - [About](#about)
 - [Setup](#setup)
 - [Request verification](#request-verification)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
