### PR TITLE
Updated okHttpVersion to the latest one

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,5 +34,5 @@
 # org.gradle.parallel=true
 
 supportLibraryVersion=26.0.0-beta2
-okHttpVersion=3.8.0
+okHttpVersion=3.8.1
 org.gradle.configureondemand=true


### PR DESCRIPTION
Updated version set in gradle.properties file to avoid problems for projects that currently use okhttp 3.8.1. 