### PR TITLE
Update to latest OkHttp 3.12.1

### DIFF
--- a/androidsample/build.gradle
+++ b/androidsample/build.gradle
@@ -60,16 +60,16 @@ dependencies {
     implementation "com.android.support:design:${supportVersion}"
     implementation "com.jakewharton:butterknife:8.8.1"
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
-    implementation "com.google.dagger:dagger:2.15"
-    implementation "com.squareup.retrofit2:retrofit:2.3.0"
-    implementation "com.squareup.retrofit2:converter-gson:2.3.0"
+    implementation "com.google.dagger:dagger:2.20"
+    implementation "com.squareup.retrofit2:retrofit:2.5.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.5.0"
     implementation "com.squareup.okhttp3:logging-interceptor:${okHttpVersion}"
     implementation "com.squareup.okhttp3:okhttp:${okHttpVersion}"
 
     implementation "com.google.code.gson:gson:2.8.5"
     implementation "com.google.code.findbugs:annotations:2.0.3"
     compileOnly "javax.annotation:jsr250-api:1.0"
-    annotationProcessor "com.google.dagger:dagger-compiler:2.15"
+    annotationProcessor "com.google.dagger:dagger-compiler:2.20"
 
     //Test dependencies
     androidTestImplementation "com.android.support.test:runner:1.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     targetSdk = 28
     minSdk = 14
     buildTools = "28.0.3"
-    okHttpVersion = "3.11.0"
+    okHttpVersion = "3.12.1"
     supportVersion = "28.0.0"
 }
 

--- a/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
+++ b/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
@@ -21,7 +21,7 @@ public class RequestMatchersTest {
     @Test
     public void endingSlashNotTakenIntoAccount() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/bar/");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/bar/");
 
         // when
         RequestMatcher matcher = RequestMatchers.pathEndsWith("bar");
@@ -33,7 +33,7 @@ public class RequestMatchersTest {
     @Test
     public void queryParamsAreTakenIntoAccount() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/bar?baz=boo");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/bar?baz=boo");
 
         // when
         RequestMatcher matcher = RequestMatchers.pathEndsWith("boo");
@@ -45,7 +45,7 @@ public class RequestMatchersTest {
     @Test
     public void queryParamsAreIgnored() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/bar?baz=boo");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/bar?baz=boo");
 
         // when
         RequestMatcher matcher = RequestMatchers.pathEndsWithIgnoringQueryParams("bar");
@@ -57,7 +57,7 @@ public class RequestMatchersTest {
     @Test
     public void shouldRecognizeProperQueryParameters() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/bar?baz=ban");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/bar?baz=ban");
 
         // when
         RequestMatcher matcher = RequestMatchers.hasQueryParameters();
@@ -69,7 +69,7 @@ public class RequestMatchersTest {
     @Test
     public void shouldMatchProperSubsetOfQueryParametersNames() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/?bar=bar&baz=baz&boo=boo");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/?bar=bar&baz=baz&boo=boo");
 
         // when
         RequestMatcher matcher = RequestMatchers.hasQueryParameterNames("bar", "baz");
@@ -81,7 +81,7 @@ public class RequestMatchersTest {
     @Test
     public void shouldNotMatchInproperSubsetOfQueryParametersNames() throws IOException {
         // given
-        RecordedRequest recordedRequest = createRecordedRequest("foo/?bar=bar&baz=baz&boo=boo");
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/?bar=bar&baz=baz&boo=boo");
 
         // when
         RequestMatcher matcher = RequestMatchers.hasQueryParameterNames("bar", "ban");
@@ -93,7 +93,7 @@ public class RequestMatchersTest {
     @Test
     public void hasHeaderNamesFailWhenNoHeaders() {
         //given
-        RecordedRequest request = createRecordedRequest("path");
+        RecordedRequest request = createRecordedRequest("/path");
 
         //when
         RequestMatcher matcher = hasHeaderNames("header1");
@@ -105,7 +105,7 @@ public class RequestMatchersTest {
     @Test
     public void hasHeaderNamesSuccessWhenMatchesAll() {
         //given
-        RecordedRequest request = createRecordedRequest("path", "h1", "v1", "h2", "v2", "h3", "v3");
+        RecordedRequest request = createRecordedRequest("/path", "h1", "v1", "h2", "v2", "h3", "v3");
 
         //when
         RequestMatcher matcher = hasHeaderNames("h1", "h2", "h3");
@@ -117,7 +117,7 @@ public class RequestMatchersTest {
     @Test
     public void hasHeaderNamesSuccessWhenMatchesAllAsSubset() {
         //given
-        RecordedRequest request = createRecordedRequest("path", "h1", "v1", "h2", "v2", "h3", "v3");
+        RecordedRequest request = createRecordedRequest("/path", "h1", "v1", "h2", "v2", "h3", "v3");
 
         //when
         RequestMatcher matcher = hasHeaderNames("h1", "h2");

--- a/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
+++ b/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
@@ -128,7 +128,7 @@ public class RequestMatchersTest {
 
     private RecordedRequest createRecordedRequest(String path, String... headerNamesAndValues) {
         Socket socket = Mockito.mock(Socket.class);
-        when(socket.getInetAddress()).thenReturn(mock(InetAddress.class));
+        when(socket.getLocalAddress()).thenReturn(mock(InetAddress.class));
         Headers headers = null;
         if (headerNamesAndValues != null && headerNamesAndValues.length >= 2) {
             headers = Headers.of(headerNamesAndValues);


### PR DESCRIPTION
First off thanks for adding HTTPS support!

When switching to use that today I hit this OkHttp bug: https://github.com/square/okhttp/issues/4183. I see that it got fixed in OkHttp 3.12.0: https://github.com/square/okhttp/pull/4373 I'd like to have that update here as well so I can switch to HTTPS.