### PR TITLE
Add the ability to remove a mock using Matcher<RecordedRequest>

### DIFF
--- a/core/src/main/java/io/appflate/restmock/MatchableCallsRequestDispatcher.java
+++ b/core/src/main/java/io/appflate/restmock/MatchableCallsRequestDispatcher.java
@@ -16,6 +16,8 @@
 
 package io.appflate.restmock;
 
+import org.hamcrest.Matcher;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.LinkedList;
@@ -130,6 +132,15 @@ class MatchableCallsRequestDispatcher extends Dispatcher {
     boolean removeMatchableCall(final MatchableCall call) {
         RESTMockServer.getLogger().log("## Removing response for:\t" + call.requestMatcher);
         return matchableCalls.remove(call);
+    }
+
+    boolean removeMatchableCall(Matcher<RecordedRequest> recordedRequest) {
+        for (MatchableCall match : matchableCalls) {
+            if (match.requestMatcher == recordedRequest) {
+                return removeMatchableCall(match);
+            }
+        }
+        return false;
     }
 
     List<RecordedRequest> getRequestHistory() {

--- a/core/src/main/java/io/appflate/restmock/RESTMockServer.java
+++ b/core/src/main/java/io/appflate/restmock/RESTMockServer.java
@@ -244,7 +244,7 @@ public class RESTMockServer {
         removeMatchableCall(requestMatcher);
         return new MatchableCall(RESTMockServer.RESTMockFileParser, requestMatcher, dispatcher);
     }
-    shouldNotMatchInproperSubsetOfQueryParametersNames
+
     /**
      * Shuts down the instance of RESTMockServer
      *

--- a/core/src/main/java/io/appflate/restmock/RESTMockServer.java
+++ b/core/src/main/java/io/appflate/restmock/RESTMockServer.java
@@ -142,6 +142,16 @@ public class RESTMockServer {
     }
 
     /**
+     * removes the {@code MatchableCall} from this {@code RESTMockServer} based on the given {@code Matcher<RecordedRequest>}
+     *
+     * @param recordedRequest {@code Matcher<RecordedRequest>} to be removed
+     * @return true if the {@code MatchableCall} was successfully removed, false if it was not found
+     */
+    public static boolean removeMatchableCall(Matcher<RecordedRequest> recordedRequest) {
+        return dispatcher.removeMatchableCall(recordedRequest);
+    }
+
+    /**
      * replaces {@code call} with {@code replacement} in this {@code RESTMockServer}
      *
      * @param call {@code MatchableCall} to be removed from {@code RESTMockServer}
@@ -231,9 +241,10 @@ public class RESTMockServer {
      * @return a MatchableCall that will get matched by the {@code requestMatcher}
      */
     public static MatchableCall whenRequested(Matcher<RecordedRequest> requestMatcher) {
+        removeMatchableCall(requestMatcher);
         return new MatchableCall(RESTMockServer.RESTMockFileParser, requestMatcher, dispatcher);
     }
-
+    shouldNotMatchInproperSubsetOfQueryParametersNames
     /**
      * Shuts down the instance of RESTMockServer
      *

--- a/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
+++ b/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
@@ -79,7 +79,7 @@ public class RequestMatchersTest {
     }
 
     @Test
-    public void shouldNotMatchInproperSubsetOfQueryParametersNames() throws IOException {
+    public void shouldNotMatchImproperSubsetOfQueryParametersNames() throws IOException {
         // given
         RecordedRequest recordedRequest = createRecordedRequest("foo/?bar=bar&baz=baz&boo=boo");
 


### PR DESCRIPTION
There's two change here:

Added an overload to removeMatchableCall that takes a parameter `Matcher<RecordedRequest>`

whenRequested, now will remove the previously mock using the removeMatchableCall that takes requesteMatcher as a parameter.

This PR is linked to #86 