### PR TITLE
add new predefined matcher to check whether URL's path exactly matches another path

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ RESTMockServer.whenGET(pathContains("users/defunkt")).thenAnswer(new MockAnswer(
 
 
 #### Step 5: Request Matchers
-You can either use some of the predefined matchers from `RequestMatchers` util class, or create your own. remember to extend from `RequestMatcher`
+You can either use some of the predefined matchers from `RequestMatchers` util class, or create your own. Remember to extend from `RequestMatcher`
 
 #### Step 6: Specify API Endpoint
 The most important step, in order for your app to communicate with the testServer, you have to specify it as an endpoint for all your API calls. For that, you can use the ` RESTMockServer.getUrl()`. If you use Retrofit, it is as easy as:

--- a/androidsample/build.gradle
+++ b/androidsample/build.gradle
@@ -57,8 +57,8 @@ configurations.all {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "androidx.appcompat:appcompat:1.3.1"
-    implementation "com.google.android.material:material:1.4.0"
+    implementation "androidx.appcompat:appcompat:1.4.2"
+    implementation "com.google.android.material:material:1.6.1"
     //noinspection AnnotationProcessorOnCompilePath
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
@@ -69,7 +69,7 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okHttpVersion"
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
 
-    implementation "com.google.code.gson:gson:2.8.6"
+    implementation "com.google.code.gson:gson:2.9.0"
     implementation "com.google.code.findbugs:annotations:2.0.3"
     compileOnly "javax.annotation:jsr250-api:1.0"
 
@@ -81,13 +81,13 @@ dependencies {
 
     //this dependency tends to break things for most users. Im adding it to check whether the app compiles correctly
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")
-    androidTestImplementation "androidx.annotation:annotation:1.2.0"
+    androidTestImplementation "androidx.annotation:annotation:1.4.0"
 
     //the most important, RESTMock! :)
     androidTestImplementation project(":android")
 
-    testImplementation "androidx.appcompat:appcompat:1.3.1"
-    testImplementation "com.google.android.material:material:1.4.0"
+    testImplementation "androidx.appcompat:appcompat:1.4.2"
+    testImplementation "com.google.android.material:material:1.6.1"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     testImplementation("androidx.test.espresso:espresso-contrib:$espressoVersion")

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,12 @@ ext {
     targetSdk = 29
     minSdk = 21
     buildTools = "29.0.2"
-    okHttpVersion = "4.9.1"
-    butterKnifeVersion = "10.2.1"
+    okHttpVersion = "4.9.3"
+    butterKnifeVersion = "10.2.3"
     espressoVersion = "3.4.0"
     junitVersion = "4.13.2"
     androidXTestVersion = "1.4.0"
-    daggerVersion = "2.27"
+    daggerVersion = "2.40.5"
 }
 
 allprojects {

--- a/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
+++ b/core/src/main/java/io/appflate/restmock/utils/RequestMatchers.java
@@ -77,12 +77,33 @@ public final class RequestMatchers {
     }
 
     public static RequestMatcher pathEndsWithIgnoringQueryParams(final String endOfUrlPath) {
-        return new RequestMatcher("path ends with: ${endOfUrlPath}") {
+        return new RequestMatcher("path ends with: " + endOfUrlPath) {
 
             protected boolean matchesSafely(RecordedRequest item) {
                 String endOfPathSanitized = sanitizePath(endOfUrlPath);
                 String recordedPathSanitized = sanitizePath(item.getPath());
                 return recordedPathSanitized.endsWith(endOfPathSanitized);
+            }
+        };
+    }
+
+    /**
+     * Checks whether matched request's path is exactly equal to given string.
+     * path is a part of the url after the server's url. Example:
+     * {@code pathEqualsToWithIgnoringQueryParams("login")} would match {@code https://localhost:4583/login}
+     * but would not match {@code https://localhost:4583/user/login}
+     *
+     * @param fullUrlPath desired path we want to match equality with
+     * @return A new {@link RequestMatcher} object that will match {@link RecordedRequest} if it's
+     * path exactly equal to given fullUrlPath
+     */
+    public static RequestMatcher pathEqualsToWithIgnoringQueryParams(final String fullUrlPath) {
+        return new RequestMatcher("path equals to: " + fullUrlPath) {
+            @Override
+            protected boolean matchesSafely(RecordedRequest item) {
+                String fullPathSanitized = sanitizePath(fullUrlPath);
+                String recordedPathSanitized = sanitizePath(item.getPath());
+                return recordedPathSanitized.equals(fullPathSanitized);
             }
         };
     }

--- a/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
+++ b/core/src/test/java/io/appflate/restmock/utils/RequestMatchersTest.java
@@ -57,6 +57,18 @@ public class RequestMatchersTest {
     }
 
     @Test
+    public void pathsAreNotEqualsAndQueryParamsAreIgnored() throws IOException {
+        // given
+        RecordedRequest recordedRequest = createRecordedRequest("/foo/bar?baz=boo");
+
+        // when
+        RequestMatcher matcher = RequestMatchers.pathEqualsToWithIgnoringQueryParams("qwe/foo/bar?baz=boo");
+
+        // then
+        assertFalse(matcher.matches(recordedRequest));
+    }
+
+    @Test
     public void shouldRecognizeProperQueryParameters() throws IOException {
         // given
         RecordedRequest recordedRequest = createRecordedRequest("/foo/bar?baz=ban");


### PR DESCRIPTION
One more predefined matcher is being added to exactly compare two URL paths. Might be useful for the case when you need to distinguish paths like `foo/bar/qwe` and `foo/bar` or `foo/bar/qwe` and `bar/qwe` when `startWith` or `endWith` matchers are not helpful.

Unit tests also added to cover new matcher.